### PR TITLE
1차 배치 관련 수정사항 반영

### DIFF
--- a/jobs/my_job/first_evaluation_job.go
+++ b/jobs/my_job/first_evaluation_job.go
@@ -71,7 +71,7 @@ func (s *DecideAppliedScreeningStep) Processor(batchContext *jobs.BatchContext, 
 	}
 
 	// 합격/불합격자 구분 처리
-	err = decideFailedApplicants(db)
+	err = decidePassApplicants(db)
 	if err != nil {
 		return err
 	}
@@ -163,8 +163,9 @@ func applyGeneralScreening(db *gorm.DB) {
 	)
 }
 
-// 불합격자 처리.
-func decideFailedApplicants(db *gorm.DB) error {
+// 합격자/불합격자 처리.
+func decidePassApplicants(db *gorm.DB) error {
+	log.Println("지원자의 합격, 불합격 여부를 적용합니다.")
 	return repository.SaveFirstTestPassYn(db)
 }
 

--- a/jobs/my_job/first_evaluation_job.go
+++ b/jobs/my_job/first_evaluation_job.go
@@ -71,7 +71,11 @@ func (s *DecideAppliedScreeningStep) Processor(batchContext *jobs.BatchContext, 
 	}
 
 	// 합격/불합격자 구분 처리
-	decideFailedApplicants(db)
+	err = decideFailedApplicants(db)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -160,8 +164,8 @@ func applyGeneralScreening(db *gorm.DB) {
 }
 
 // 불합격자 처리.
-func decideFailedApplicants(db *gorm.DB) {
-	repository.SaveFirstTestPassYn()
+func decideFailedApplicants(db *gorm.DB) error {
+	return repository.SaveFirstTestPassYn(db)
 }
 
 func logAppliedScreeningResult(wantedScreening types.Screening, success1E int, applicantCount int) {

--- a/jobs/my_job/first_evaluation_job.go
+++ b/jobs/my_job/first_evaluation_job.go
@@ -34,11 +34,11 @@ func (s *DecideAppliedScreeningStep) Processor(batchContext *jobs.BatchContext, 
 
 	// 정원 외 특별전형 평가
 	// 특례 대상
-	extraAdCount := repository.CountOneseoByAppliedScreening(string(types.ExtraAdmissionScreening))
+	extraAdCount := repository.CountOneseoByWantedScreening(string(types.ExtraAdmissionScreening))
 	logAppliedScreeningResult(types.ExtraAdmissionScreening, types.ExtraAdmissionSuccessfulApplicantOf1E, extraAdCount)
 	applyExtraAdScreening(db)
 	// 국가 보훈 대상
-	extraVeCount := repository.CountOneseoByAppliedScreening(string(types.ExtraVeteransScreening))
+	extraVeCount := repository.CountOneseoByWantedScreening(string(types.ExtraVeteransScreening))
 	logAppliedScreeningResult(types.ExtraVeteransScreening, types.ExtraVeteransSuccessfulApplicantOf1E, extraVeCount)
 	applyExtraVeScreening(db)
 

--- a/repository/first_evaluation_job_repository.go
+++ b/repository/first_evaluation_job_repository.go
@@ -17,15 +17,6 @@ func CountOneseoByWantedScreening(wantedScreening string) int {
 	return result
 }
 
-func CountOneseoByAppliedScreening(wantedScreening string) int {
-	var result int
-	tx := configs.MyDB.Raw("select count(*) from tb_oneseo where wanted_screening = ?", wantedScreening).Scan(&result)
-	if tx.Error != nil {
-		log.Println(tx.Error.Error())
-	}
-	return result
-}
-
 func SaveAppliedScreening(db *gorm.DB, evaluateScreening []string, appliedScreening string, top int) error {
 	query := fmt.Sprintf(`
 update tb_oneseo tbo

--- a/repository/first_evaluation_job_repository.go
+++ b/repository/first_evaluation_job_repository.go
@@ -54,7 +54,8 @@ func SaveFirstTestPassYn(db *gorm.DB) error {
 	query := `
 update tb_entrance_test_result tbe
     join tb_oneseo tbo on tbe.oneseo_id = tbo.oneseo_id
-set tbe.first_test_pass_yn = IF(tbo.applied_screening is not null and tbo.real_oneseo_arrived_yn = 'YES', 'YES', 'NO')
+set tbe.first_test_pass_yn = IF(tbo.applied_screening is not null and tbo.real_oneseo_arrived_yn = 'YES', 'YES', 'NO'),
+    tbo.pass_yn = IF(tbo.applied_screening is not null and tbo.real_oneseo_arrived_yn = 'YES', null, 'NO')
 where tbo.oneseo_id is not null;
 `
 	return e.WrapRollbackNeededError(db.Exec(query).Error)

--- a/repository/first_evaluation_job_repository.go
+++ b/repository/first_evaluation_job_repository.go
@@ -10,7 +10,7 @@ import (
 
 func CountOneseoByWantedScreening(wantedScreening string) int {
 	var result int
-	tx := configs.MyDB.Raw("select count(*) from tb_oneseo where wanted_screening = ?", wantedScreening).Scan(&result)
+	tx := configs.MyDB.Raw("select count(*) from tb_oneseo where wanted_screening = ? and real_oneseo_arrived_yn = 'YES'", wantedScreening).Scan(&result)
 	if tx.Error != nil {
 		log.Println(tx.Error.Error())
 	}
@@ -25,7 +25,8 @@ update tb_oneseo tbo
                    join tb_entrance_test_result tbe
                         on tbo_inner.oneseo_id = tbe.oneseo_id
           where tbo_inner.wanted_screening in ?
-            and tbo_inner.applied_screening is null
+            and tbo_inner.applied_screening is null 
+    		and real_oneseo_arrived_yn = 'YES'
           order by tbe.document_evaluation_score
           LIMIT ?) as limited_tbo
     on tbo.oneseo_id = limited_tbo.oneseo_id
@@ -37,15 +38,15 @@ where tbo.oneseo_id is not null
 
 func IsAppliedScreeningAllNull() bool {
 	var result int
-	configs.MyDB.Raw("select count(*) from tb_oneseo where applied_screening is not null").Scan(&result)
+	configs.MyDB.Raw("select count(*) from tb_oneseo where applied_screening is not null and real_oneseo_arrived_yn = 'YES'").Scan(&result)
 	return result < 1
 }
 
 func IsAppliedScreeningAllNullBy(wantedScreening string) bool {
 	var totalCount int
 	var nullCount int
-	configs.MyDB.Raw("select count(*) from tb_oneseo where wanted_screening = ?", wantedScreening).Scan(&totalCount)
-	configs.MyDB.Raw("select count(*) from tb_oneseo where wanted_screening = ? and applied_screening is null", wantedScreening).Scan(&nullCount)
+	configs.MyDB.Raw("select count(*) from tb_oneseo where wanted_screening = ? and real_oneseo_arrived_yn = 'YES'", wantedScreening).Scan(&totalCount)
+	configs.MyDB.Raw("select count(*) from tb_oneseo where wanted_screening = ? and applied_screening is null and real_oneseo_arrived_yn = 'YES'", wantedScreening).Scan(&nullCount)
 	return totalCount == nullCount
 }
 
@@ -53,7 +54,7 @@ func SaveFirstTestPassYn(db *gorm.DB) error {
 	query := `
 update tb_entrance_test_result tbe
     join tb_oneseo tbo on tbe.oneseo_id = tbo.oneseo_id
-set tbe.first_test_pass_yn = IF(tbo.applied_screening is not null, 'YES', 'NO')
+set tbe.first_test_pass_yn = IF(tbo.applied_screening is not null and tbo.real_oneseo_arrived_yn = 'YES', 'YES', 'NO')
 where tbo.oneseo_id is not null;
 `
 	return e.WrapRollbackNeededError(db.Exec(query).Error)

--- a/repository/first_evaluation_job_repository.go
+++ b/repository/first_evaluation_job_repository.go
@@ -17,9 +17,9 @@ func CountOneseoByWantedScreening(wantedScreening string) int {
 	return result
 }
 
-func CountOneseoByAppliedScreening(appliedScreening string) int {
+func CountOneseoByAppliedScreening(wantedScreening string) int {
 	var result int
-	tx := configs.MyDB.Raw("select count(*) from tb_oneseo where applied_screening = ?", appliedScreening).Scan(&result)
+	tx := configs.MyDB.Raw("select count(*) from tb_oneseo where wanted_screening = ?", wantedScreening).Scan(&result)
 	if tx.Error != nil {
 		log.Println(tx.Error.Error())
 	}
@@ -58,12 +58,12 @@ func IsAppliedScreeningAllNullBy(wantedScreening string) bool {
 	return totalCount == nullCount
 }
 
-func SaveFirstTestPassYn() {
+func SaveFirstTestPassYn(db *gorm.DB) error {
 	query := `
 update tb_entrance_test_result tbe
     join tb_oneseo tbo on tbe.oneseo_id = tbo.oneseo_id
 set tbe.first_test_pass_yn = IF(tbo.applied_screening is not null, 'YES', 'NO')
 where tbo.oneseo_id is not null;
 `
-	configs.MyDB.Exec(query)
+	return e.WrapRollbackNeededError(db.Exec(query).Error)
 }

--- a/resources/application-local.yaml
+++ b/resources/application-local.yaml
@@ -2,7 +2,7 @@ mysql:
   host: 127.0.0.1
   port: 3306
   username: root
-  password: 12345
+  password: 1234
   database: hellogsm
 api:
   relay-api:

--- a/resources/application-local.yaml
+++ b/resources/application-local.yaml
@@ -2,7 +2,7 @@ mysql:
   host: 127.0.0.1
   port: 3306
   username: root
-  password: 1234
+  password: 12345
   database: hellogsm
 api:
   relay-api:


### PR DESCRIPTION
- `applied_screening` 컬럼은 1차 배치 이전에는 NULL 값이 할당되어있기 때문에, count 쿼리에 조건을 `applied_screening` -> `wanted_screening`으로 변경하였습니다.
- `real_oneseo_arrived_yn - 실물원서제출여부` 컬럼이 YES인 지원자를 대상으로만 배치 작업을 진행하도록 where 조건절에 추가하였습니다.
- 1차 배치 합격자/불합격자 처리 관련 작업을 마무리하였습니다.
   - 1차 배치 불합격자는 `tb_oneseo` 테이블에 추가된 `pass_yn - 최종합격여부` 컬럼에 `NO`를 할당하도록 작업하였습니다.