### PR TITLE
2차(서류 + 직무적성 + 심층면접)전형 합불 결정 배치 구현

### DIFF
--- a/jobs/my_job/second_evaluation_job.go
+++ b/jobs/my_job/second_evaluation_job.go
@@ -1,10 +1,128 @@
 package my_job
 
 import (
+	"log"
+	e "themoment-team/go-hellogsm/error"
 	"themoment-team/go-hellogsm/internal"
 	"themoment-team/go-hellogsm/jobs"
+	"themoment-team/go-hellogsm/repository"
+	"themoment-team/go-hellogsm/types"
+
+	"gorm.io/gorm"
 )
 
+// SecondEvaluationAbsenteeExclusionStep 2차 전형(직무적성검사 or 심층면접) 미응시자를 탈락 처리하는 Step 이다.
+type SecondEvaluationAbsenteeExclusionStep struct {
+}
+
+// TotalEvaluationTopScoringApplicantsSelectionByScreeningStep 모든 평가(1차 + 2차)를 기반으로 상위 성적의 지원자들을 전형별로 선발하는 Step 이다.
+type TotalEvaluationTopScoringApplicantsSelectionByScreeningStep struct {
+}
+
+// job 에 필요한 step 들을 반환한다.
+func getSecondEvaluationSteps() []jobs.Step {
+	return []jobs.Step{&SecondEvaluationAbsenteeExclusionStep{}, &TotalEvaluationTopScoringApplicantsSelectionByScreeningStep{}}
+}
+
+// BuildSecondEvaluationJob 2차 평가 배치 Job을 생성한다.
 func BuildSecondEvaluationJob(properties internal.ApplicationProperties) *jobs.SimpleJob {
+	return jobs.NewSimpleJob(internal.SecondEvaluationJob, getSecondEvaluationSteps(), nil)
+}
+
+func (s *SecondEvaluationAbsenteeExclusionStep) Processor(context *jobs.BatchContext, db *gorm.DB) error { // 하나 트랜잭션으로 묶
+	// 처리 전 데이터 검증
+	err := PreCheckAbsenteeExclusion()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// 2차 전형 미응시자 탈락 처리
+	log.Printf("2차 전형(직무적성검사 or 심층면접) 미응시자를 탈락 처리합니다")
+	repository.UpdateSecondTestPassStatusForAbsentees()
+
+	// 처리 후 데이터 검증
+	err = PostCheckAbsenteeExclusion()
+	if err != nil {
+		panic(err.Error())
+	}
+}
+
+// 1차 평가를 마친 data는 applied_screening이 존재햐야 한다.
+func PreCheckAbsenteeExclusion() error {
+	isAllNotNull := repository.IsAllFirstPassUserHaveAppliedScreening()
+	if isAllNotNull == false {
+		return e.WrapExpectedActualIsDiffError("1차 평가를 마친 data는 전부 applied_screening이 존재햐야 한다.")
+	}
+
 	return nil
+}
+
+// 2차 전형(직무적성검사 or 심층면접) 미응시자는 탈락처리 되어있다.
+func PostCheckAbsenteeExclusion() error {
+	isAllAbsenteeFall := repository.IsAllAbsenteeFall()
+	if isAllAbsenteeFall == false {
+		return e.WrapExpectedActualIsDiffError("2차 전형(직무적성검사 or 심층면접) 미응시자는 전부 탈락처리 되어있다.")
+	}
+
+	return nil
+}
+
+func (s *TotalEvaluationTopScoringApplicantsSelectionByScreeningStep) Processor(context *jobs.BatchContext, db *gorm.DB) error {
+	log.Println("정원외특별전형(특례)으로 2차 전형에 응시한 지원자를 조회합니다.")
+	extraAdOneseoIds := repository.QueryExtraAdOneseoIds()
+	processGroup(
+		types.ExtraAdmissionScreening,
+		types.SpecialScreening,
+		extraAdOneseoIds,
+		types.ExtraAdmissionSuccessfulApplicantOf2E,
+		repository.UpdateSecondTestPassYnForExtraAdPass,
+		repository.UpdateAppliedScreeingForExtraAdFall,
+	)
+
+	log.Println("정원외특별전형(국가보훈)으로 2차 전형에 응시한 지원자를 조회합니다.")
+	extraVeOneseoIds := repository.QueryExtraVeOneseoIds()
+	processGroup(
+		types.ExtraVeteransScreening,
+		types.SpecialScreening,
+		extraVeOneseoIds,
+		types.ExtraVeteransSuccessfulApplicantOf2E,
+		repository.UpdateSecondTestPassYnForExtraVePass,
+		repository.UpdateAppliedScreeingForExtraVeFall,
+	)
+
+	log.Println("특별전형으로 2차 전형에 응시한 지원자를 조회합니다.")
+	specialOneseoIds := repository.QuerySpecialOneseoIds()
+	remainingSpecialOneseos := processGroup(
+		types.SpecialScreening,
+		types.GeneralScreening,
+		specialOneseoIds,
+		types.SpecialSuccessfulApplicantOf2E,
+		repository.UpdateSecondTestPassYnForSpecialPass,
+		repository.UpdateAppliedScreeingForSpecialFall,
+	)
+
+	log.Printf("일반전형으로 2차 전형을 진행한 인원 중 성적 상위 %d명을 합격처리하고, 나머지 지원자를 탈락처리합니다.", types.GeneralSuccessfulApplicantOf2E+remainingSpecialOneseos)
+	requiredGeneralOneseos := types.GeneralSuccessfulApplicantOf2E + remainingSpecialOneseos
+	repository.UpdateSecondTestPassYnForGeneral(requiredGeneralOneseos)
+}
+
+// groupName, fallbackScreening은 log용 param
+func processGroup(groupName types.Screening, fallbackScreening types.Screening, ids []int, limit int, passUpdater, fallUpdater func([]int)) int {
+	if len(ids) <= limit {
+		log.Printf("%s(으)로 2차 전형을 진행한 인원이 %d명 이하일 때 전부 합격처리합니다.", groupName, limit)
+		passUpdater(ids)
+		return limit - len(ids)
+	}
+
+	log.Printf("%s(으)로 2차 전형을 진행한 인원이 %d명 초과일 때", groupName, limit)
+	passIds := ids[:limit]
+	fallIds := ids[limit:]
+
+	log.Printf("상위 %d명은 합격처리", limit)
+	passUpdater(passIds)
+
+	log.Printf("하위 %d명은 %s(으)로 변경합니다.", len(fallIds), fallbackScreening)
+	fallUpdater(fallIds)
+
+	return 0
 }

--- a/repository/second_evaluation_job_repository.go
+++ b/repository/second_evaluation_job_repository.go
@@ -1,0 +1,233 @@
+package repository
+
+import (
+	"themoment-team/go-hellogsm/configs"
+)
+
+func UpdateSecondTestPassStatusForAbsentees() {
+	configs.MyDB.Exec(`
+		UPDATE tb_entrance_test_result
+		SET second_test_pass_yn = 'NO'
+		WHERE first_test_pass_yn = 'YES' 
+		  AND (aptitude_evaluation_score IS NULL OR interview_score IS NULL)
+	`)
+}
+
+func IsAllFirstPassUserHaveAppliedScreening() bool {
+	var result int
+	configs.MyDB.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_oneseo 
+		WHERE applied_screening IS NULL 
+		  AND oneseo_id IN (
+			SELECT oneseo_id 
+			FROM tb_entrance_test_result 
+			WHERE first_test_pass_yn = 'YES'
+		)
+	`).Scan(&result)
+	return result < 1
+}
+
+func IsAllAbsenteeFall() bool {
+	var absenteeCount int
+	var fallCount int
+
+	// 미응시자 count query
+	configs.MyDB.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_entrance_test_result 
+		WHERE first_test_pass_yn = 'YES' 
+		  AND (aptitude_evaluation_score IS NULL OR interview_score IS NULL)
+	`).Scan(&absenteeCount)
+
+	// 2차 전형 탈락자 count query
+	configs.MyDB.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_entrance_test_result 
+		WHERE second_test_pass_yn = 'NO'
+	`).Scan(&fallCount)
+
+	return absenteeCount == fallCount
+}
+
+// extra admission oneseo id조회 쿼리 (성적순으로 order)
+func QueryExtraAdOneseoIds() []int {
+	var ids []int
+	configs.MyDB.Raw(`
+		SELECT o.oneseo_id 
+		FROM tb_oneseo o
+		JOIN tb_entrance_test_result tr ON o.oneseo_id = tr.oneseo_id
+		JOIN tb_entrance_test_factors_detail td ON tr.entrance_test_factors_detail_id = td.entrance_test_factors_detail_id
+		JOIN tb_member m ON o.member_id = m.member_id
+		WHERE 
+			o.applied_screening = 'EXTRA_ADMISSION' 
+			AND tr.second_test_pass_yn IS NULL
+		ORDER BY 
+			(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+			td.total_subjects_score DESC,
+			(td.score_3_2 + td.score_3_1) DESC,
+			(td.score_2_2 + td.score_2_1) DESC, 
+			td.score_2_2 DESC, 
+			td.score_2_1 DESC, 
+			td.total_non_subjects_score DESC, 
+			m.birth ASC;
+	`).Scan(&ids)
+
+	return ids
+}
+
+// extra admission limit명 이하일때 second_test = pass
+func UpdateSecondTestPassYnForExtraAdPass(passExtraAdOneseoIds []int) {
+
+	// second_test_pass_yn = YES
+	configs.MyDB.Exec(`
+		UPDATE tb_entrance_test_result
+		SET second_test_pass_yn = 'YES'
+		WHERE oneseo_id IN ?
+	`, passExtraAdOneseoIds)
+}
+
+// extra admission limit명 초과일때 하위 n명 applied_screening = SPECIAL 설정 쿼리
+func UpdateAppliedScreeingForExtraAdFall(fallExtraAdOneseoIds []int) {
+	configs.MyDB.Exec(`
+		UPDATE tb_oneseo
+		SET applied_screening = 'SPECIAL'
+		WHERE oneseo_id IN ?
+	`, fallExtraAdOneseoIds)
+}
+
+// extra veteran oneseo id조회 쿼리 (성적순으로 order)
+func QueryExtraVeOneseoIds() []int {
+	var ids []int
+	configs.MyDB.Raw(`
+		SELECT o.oneseo_id 
+		FROM tb_oneseo o
+		JOIN tb_entrance_test_result tr ON o.oneseo_id = tr.oneseo_id
+		JOIN tb_entrance_test_factors_detail td ON tr.entrance_test_factors_detail_id = td.entrance_test_factors_detail_id
+		JOIN tb_member m ON o.member_id = m.member_id
+		WHERE 
+			o.applied_screening = 'EXTRA_VETERANS' 
+			AND tr.second_test_pass_yn IS NULL
+		ORDER BY 
+			(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+			td.total_subjects_score DESC,
+			(td.score_3_2 + td.score_3_1) DESC,
+			(td.score_2_2 + td.score_2_1) DESC, 
+			td.score_2_2 DESC, 
+			td.score_2_1 DESC, 
+			td.total_non_subjects_score DESC, 
+			m.birth ASC;
+	`).Scan(&ids)
+
+	return ids
+}
+
+// extra veteran limit명 이하일때 second_test = pass
+func UpdateSecondTestPassYnForExtraVePass(passExtraVeOneseoIds []int) {
+
+	// second_test_pass_yn = YES
+	configs.MyDB.Exec(`
+		UPDATE tb_entrance_test_result
+		SET second_test_pass_yn = 'YES'
+		WHERE oneseo_id IN ?
+	`, passExtraVeOneseoIds)
+}
+
+// extra veteran limit명 초과일때 하위 n명 applied_screening = SPECIAL 설정 쿼리
+func UpdateAppliedScreeingForExtraVeFall(fallExtraVeOneseoIds []int) {
+	configs.MyDB.Exec(`
+		UPDATE tb_oneseo
+		SET applied_screening = 'SPECIAL'
+		WHERE oneseo_id IN ?
+	`, fallExtraVeOneseoIds)
+}
+
+// special oneseo id조회 쿼리 (성적순으로 order)
+func QuerySpecialOneseoIds() []int {
+	var ids []int
+	configs.MyDB.Raw(`
+		SELECT o.oneseo_id 
+		FROM tb_oneseo o
+		JOIN tb_entrance_test_result tr ON o.oneseo_id = tr.oneseo_id
+		JOIN tb_entrance_test_factors_detail td ON tr.entrance_test_factors_detail_id = td.entrance_test_factors_detail_id
+		JOIN tb_member m ON o.member_id = m.member_id
+		WHERE 
+			o.applied_screening = 'SPECIAL'
+			AND tr.second_test_pass_yn IS NULL
+		ORDER BY 
+			(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+			td.total_subjects_score DESC,
+			(td.score_3_2 + td.score_3_1) DESC,
+			(td.score_2_2 + td.score_2_1) DESC, 
+			td.score_2_2 DESC, 
+			td.score_2_1 DESC, 
+			td.total_non_subjects_score DESC, 
+			m.birth ASC;
+	`).Scan(&ids)
+
+	return ids
+}
+
+// special limit명 이하일때 second_test = pass
+func UpdateSecondTestPassYnForSpecialPass(passSpecialOneseoIds []int) {
+
+	// second_test_pass_yn = YES
+	configs.MyDB.Exec(`
+		UPDATE tb_entrance_test_result
+		SET second_test_pass_yn = 'YES'
+		WHERE oneseo_id IN ?
+	`, passSpecialOneseoIds)
+}
+
+// special limit명 초과일때 하위 n명 applied_screening = general 설정 쿼리
+func UpdateAppliedScreeingForSpecialFall(fallSpecialOneseoIds []int) {
+	configs.MyDB.Exec(`
+		UPDATE tb_oneseo
+		SET applied_screening = 'GENERAL'
+		WHERE oneseo_id IN ?
+	`, fallSpecialOneseoIds)
+}
+
+// general 성적 상위 n명(limit 호출쪽에서 능동적으로) second_test = pass & 나머지 지원자 탈락 처리
+func UpdateSecondTestPassYnForGeneral(generalPassLimit int) {
+
+	// second_test_pass_yn = YES
+	configs.MyDB.Exec(`
+		UPDATE tb_entrance_test_result tr
+		JOIN (
+			SELECT tr.entrance_test_result_id 
+			FROM tb_entrance_test_result tr
+			JOIN tb_entrance_test_factors_detail td ON tr.entrance_test_factors_detail_id = td.entrance_test_factors_detail_id
+			JOIN tb_oneseo o ON tr.oneseo_id = o.oneseo_id
+			JOIN tb_member m ON o.member_id = m.member_id
+			WHERE 
+				o.applied_screening = 'GENERAL'
+				AND tr.second_test_pass_yn IS NULL
+			ORDER BY 
+				(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+				td.total_subjects_score DESC,
+				(td.score_3_2 + td.score_3_1) DESC,
+				(td.score_2_2 + td.score_2_1) DESC, 
+				td.score_2_2 DESC, 
+				td.score_2_1 DESC, 
+				td.total_non_subjects_score DESC, 
+				m.birth ASC
+			LIMIT ?
+		) AS subquery ON tr.entrance_test_result_id = subquery.entrance_test_result_id
+		SET tr.second_test_pass_yn = 'YES';
+	`, generalPassLimit)
+
+	// second_test_pass_yn = NO
+	configs.MyDB.Exec(`
+		UPDATE tb_entrance_test_result tr
+		JOIN (
+			SELECT tr.entrance_test_result_id 
+			FROM tb_entrance_test_result tr
+			JOIN tb_oneseo o ON tr.oneseo_id = o.oneseo_id
+			WHERE 
+				o.applied_screening IS NOT NULL
+				AND tr.second_test_pass_yn IS NULL
+		) AS subquery ON tr.entrance_test_result_id = subquery.entrance_test_result_id
+		SET tr.second_test_pass_yn = 'NO';
+	`)
+}

--- a/types/constant.go
+++ b/types/constant.go
@@ -26,6 +26,8 @@ const (
 
 	// [2차 평가] 전형 별 합격자 수
 	GeneralSpecialSuccessfulApplicantOf2E int = 72
+	GeneralSuccessfulApplicantOf2E        int = 64
+	SpecialSuccessfulApplicantOf2E        int = 8
 	ExtraVeteransSuccessfulApplicantOf2E  int = 2
 	ExtraAdmissionSuccessfulApplicantOf2E int = 1
 


### PR DESCRIPTION
## 개요

2차(서류 + 적성검사 + 심층면접) 배치 Job을 개발하였습니다. (`SecondEvaluationJob`)

<br>

## 본문

### SecondEvaluationJob

<br>

**step1 - SecondEvaluationAbsenteeExclusionStep**
- 해당 step은 2차 전형(직무적성검사 or 심층면접) 미응시자를 탈락 처리하는 step 입니다.
- 1차전형은 통과했지만 2차전형 중 하나 이상을 참여하지 않았을 시 `second_test_pass_yn = NO` 처리됩니다.
- step 전 검증으로 1차전형 통과자는 모두 `applied_screening`이 할당되어 있는지 검사합니다.
- step 후 검증으로 모든 2차전형 미응시자가 탈락처리 되었는지 검사합니다.

<br> 

**step2 - TotalEvaluationTopScoringApplicantsSelectionByScreeningStep**
- 해당 step은 모든 전형(1차 + 2차)을 기반으로 상위 성적의 지원자들을 전형별로 선발하는 step 입니다.
- EXTRA -> SPECIAL -> GENERAL 순으로 상위 성적자를 선별하며, 성적이 밀린 지원자는 하위 전형으로 변경됩니다.
- 최종적으로 GENERAL 전형에서 상위 성적 n명에 들지 못하는 경우 `second_test_pass_yn = NO` 처리됩니다.