### PR TITLE
1차배치 쿼리 정렬 수정

### DIFF
--- a/repository/first_evaluation_job_repository.go
+++ b/repository/first_evaluation_job_repository.go
@@ -2,10 +2,11 @@ package repository
 
 import (
 	"fmt"
-	"gorm.io/gorm"
 	"log"
 	"themoment-team/go-hellogsm/configs"
 	e "themoment-team/go-hellogsm/error"
+
+	"gorm.io/gorm"
 )
 
 func CountOneseoByWantedScreening(wantedScreening string) int {
@@ -27,7 +28,7 @@ update tb_oneseo tbo
           where tbo_inner.wanted_screening in ?
             and tbo_inner.applied_screening is null 
     		and real_oneseo_arrived_yn = 'YES'
-          order by tbe.document_evaluation_score
+          order by tbe.document_evaluation_score DESC
           LIMIT ?) as limited_tbo
     on tbo.oneseo_id = limited_tbo.oneseo_id
 set tbo.applied_screening = ?


### PR DESCRIPTION
## 작업내용

`firstEvaluationJobRepository`의 `SaveAppliedScreening` 함수의 쿼리에서 데이터를 성적 내림차순으로 가져오도록 변경