### PR TITLE
1차 평가 성적순 정렬 쿼리 정렬조건 추가

### DIFF
--- a/repository/first_evaluation_job_repository.go
+++ b/repository/first_evaluation_job_repository.go
@@ -20,19 +20,33 @@ func CountOneseoByWantedScreening(wantedScreening string) int {
 
 func SaveAppliedScreening(db *gorm.DB, evaluateScreening []string, appliedScreening string, top int) error {
 	query := fmt.Sprintf(`
-update tb_oneseo tbo
-    join (select tbo_inner.oneseo_id
-          from tb_oneseo tbo_inner
-                   join tb_entrance_test_result tbe
-                        on tbo_inner.oneseo_id = tbe.oneseo_id
-          where tbo_inner.wanted_screening in ?
-            and tbo_inner.applied_screening is null 
-    		and real_oneseo_arrived_yn = 'YES'
-          order by tbe.document_evaluation_score DESC
-          LIMIT ?) as limited_tbo
-    on tbo.oneseo_id = limited_tbo.oneseo_id
-set tbo.applied_screening = ?
-where tbo.oneseo_id is not null
+		UPDATE tb_oneseo tbo
+		JOIN (
+			SELECT tbo_inner.oneseo_id
+			FROM tb_oneseo tbo_inner
+			JOIN tb_member tbm 
+				ON tbo_inner.member_id = tbm.member_id
+			JOIN tb_entrance_test_result tbe 
+				ON tbo_inner.oneseo_id = tbe.oneseo_id
+			JOIN tb_entrance_test_factors_detail tbd 
+				ON tbe.entrance_test_result_id = tbd.entrance_test_factors_detail_id
+			WHERE tbo_inner.wanted_screening IN ?
+			  AND tbo_inner.applied_screening IS NULL
+			  AND tbo_inner.real_oneseo_arrived_yn = 'YES'
+			ORDER BY 
+				tbe.document_evaluation_score DESC,
+				tbd.total_subjects_score DESC,
+				(tbd.score_3_2 + tbd.score_3_1) DESC,
+				(tbd.score_2_2 + tbd.score_2_1) DESC,
+				tbd.score_2_2 DESC,
+				tbd.score_2_1 DESC,
+				tbd.total_non_subjects_score DESC,
+				tbm.birth ASC
+			LIMIT ?
+		) AS limited_tbo
+		ON tbo.oneseo_id = limited_tbo.oneseo_id
+		SET tbo.applied_screening = ?
+		WHERE tbo.oneseo_id IS NOT NULL;
 `)
 	return e.WrapRollbackNeededError(db.Exec(query, evaluateScreening, top, appliedScreening).Error)
 }


### PR DESCRIPTION
1차 평가에서 성적순으로 지원자를 정렬하는 쿼리에 조건을 추가하였습니다.

기존에 서류평가 환산점으로만 정렬하였는데 동점자 처리를 위한 조건을 추가하였습니다. (2차평가와 학과배정에서 성적을 정렬하는 기준과 동일한 기준 추가)

추가된 조건
```
tbe.document_evaluation_score DESC,
tbd.total_subjects_score DESC,
(tbd.score_3_2 + tbd.score_3_1) DESC,
(tbd.score_2_2 + tbd.score_2_1) DESC,
tbd.score_2_2 DESC,
tbd.score_2_1 DESC,
tbd.total_non_subjects_score DESC,
tbm.birth ASC
```