### PR TITLE
update: 동점자 처리기준 변경

### DIFF
--- a/repository/first_evaluation_job_repository.go
+++ b/repository/first_evaluation_job_repository.go
@@ -34,14 +34,13 @@ func SaveAppliedScreening(db *gorm.DB, evaluateScreening []string, appliedScreen
 			  AND tbo_inner.applied_screening IS NULL
 			  AND tbo_inner.real_oneseo_arrived_yn = 'YES'
 			ORDER BY 
-				tbe.document_evaluation_score DESC,
-				tbd.total_subjects_score DESC,
-				(tbd.score_3_2 + tbd.score_3_1) DESC,
-				(tbd.score_2_2 + tbd.score_2_1) DESC,
+				tbe.document_evaluation_score DESC, -- 1차전형 점수
+				tbd.general_subjects_score DESC, -- 일반교과성적이 우수한자
+				tbd.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
 				tbd.score_2_2 DESC,
 				tbd.score_2_1 DESC,
-				tbd.total_non_subjects_score DESC,
-				tbm.birth ASC
+				tbd.score_1_2 DESC,
+				tbd.total_non_subjects_score DESC -- 비교과성적이 우수한자
 			LIMIT ?
 		) AS limited_tbo
 		ON tbo.oneseo_id = limited_tbo.oneseo_id

--- a/repository/first_evaluation_job_repository.go
+++ b/repository/first_evaluation_job_repository.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"themoment-team/go-hellogsm/configs"
 	e "themoment-team/go-hellogsm/error"
+	"themoment-team/go-hellogsm/repository/shared"
 
 	"gorm.io/gorm"
 )
@@ -35,19 +36,14 @@ func SaveAppliedScreening(db *gorm.DB, evaluateScreening []string, appliedScreen
 			  AND tbo_inner.real_oneseo_arrived_yn = 'YES'
 			ORDER BY 
 				tbe.document_evaluation_score DESC, -- 1차전형 점수
-				tbd.general_subjects_score DESC, -- 일반교과성적이 우수한자
-				tbd.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
-				tbd.score_2_2 DESC,
-				tbd.score_2_1 DESC,
-				tbd.score_1_2 DESC,
-				tbd.total_non_subjects_score DESC -- 비교과성적이 우수한자
+				? -- 동점자 처리기준 (TieBreakerQuery)
 			LIMIT ?
 		) AS limited_tbo
 		ON tbo.oneseo_id = limited_tbo.oneseo_id
 		SET tbo.applied_screening = ?
 		WHERE tbo.oneseo_id IS NOT NULL;
 `)
-	err := db.Exec(query, evaluateScreening, top, appliedScreening).Error
+	err := db.Exec(query, evaluateScreening, shared.CommonTieBreakerQuery, top, appliedScreening).Error
 	if err != nil {
 		return e.WrapRollbackNeededError(err)
 	}

--- a/repository/first_evaluation_job_repository.go
+++ b/repository/first_evaluation_job_repository.go
@@ -27,15 +27,15 @@ func SaveAppliedScreening(db *gorm.DB, evaluateScreening []string, appliedScreen
 			FROM tb_oneseo tbo_inner
 			JOIN tb_member tbm 
 				ON tbo_inner.member_id = tbm.member_id
-			JOIN tb_entrance_test_result tbe 
-				ON tbo_inner.oneseo_id = tbe.oneseo_id
-			JOIN tb_entrance_test_factors_detail tbd 
-				ON tbe.entrance_test_result_id = tbd.entrance_test_factors_detail_id
+			JOIN tb_entrance_test_result tr 
+				ON tbo_inner.oneseo_id = tr.oneseo_id
+			JOIN tb_entrance_test_factors_detail td 
+				ON tr.entrance_test_result_id = td.entrance_test_factors_detail_id
 			WHERE tbo_inner.wanted_screening IN ?
 			  AND tbo_inner.applied_screening IS NULL
 			  AND tbo_inner.real_oneseo_arrived_yn = 'YES'
 			ORDER BY 
-				tbe.document_evaluation_score DESC, -- 1차전형 점수
+				tr.document_evaluation_score DESC, -- 1차전형 점수
 				? -- 동점자 처리기준 (TieBreakerQuery)
 			LIMIT ?
 		) AS limited_tbo

--- a/repository/major_assignment_job_repository.go
+++ b/repository/major_assignment_job_repository.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"themoment-team/go-hellogsm/configs"
 	e "themoment-team/go-hellogsm/error"
+	"themoment-team/go-hellogsm/repository/shared"
 	"themoment-team/go-hellogsm/types"
 )
 
@@ -104,14 +105,8 @@ func QueryAllByFinalTestPassApplicant() (error, []types.Applicant) {
 		      m.role = 'APPLICANT'
 		ORDER BY 
 		(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-		tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
-		td.general_subjects_score DESC, -- 일반교과성적이 우수한자
-		td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
-		td.score_2_2 DESC,
-		td.score_2_1 DESC,
-		td.score_1_2 DESC,
-		td.total_non_subjects_score DESC -- 비교과성적이 우수한자
-	`).Rows()
+		? -- 동점자 처리기준 (TieBreakerQuery)
+	`, shared.FinalTieBreakerQuery).Rows()
 
 	if err != nil {
 		log.Println(err)
@@ -150,14 +145,8 @@ func QueryAllByAdditionalApplicant() (error, []types.Applicant) {
 		      m.role = 'APPLICANT'
 		ORDER BY 
 		(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-		tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
-		td.general_subjects_score DESC, -- 일반교과성적이 우수한자
-		td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
-		td.score_2_2 DESC,
-		td.score_2_1 DESC,
-		td.score_1_2 DESC,
-		td.total_non_subjects_score DESC -- 비교과성적이 우수한자
-	`).Rows()
+		? -- 동점자 처리기준 (TieBreakerQuery)
+	`, shared.FinalTieBreakerQuery).Rows()
 
 	if err != nil {
 		log.Println(err)

--- a/repository/major_assignment_job_repository.go
+++ b/repository/major_assignment_job_repository.go
@@ -103,14 +103,14 @@ func QueryAllByFinalTestPassApplicant() (error, []types.Applicant) {
 		      o.entrance_intention_yn IS NULL AND 
 		      m.role = 'APPLICANT'
 		ORDER BY 
-		(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-		td.total_subjects_score DESC, 
-		(td.score_3_2 + td.score_3_1) DESC,
-		(td.score_2_2 + td.score_2_1) DESC, 
-		td.score_2_2 DESC, 
-		td.score_2_1 DESC, 
-		td.total_non_subjects_score DESC, 
-		m.birth ASC;
+		(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+		tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
+		td.general_subjects_score DESC, -- 일반교과성적이 우수한자
+		td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
+		td.score_2_2 DESC,
+		td.score_2_1 DESC,
+		td.score_1_2 DESC,
+		td.total_non_subjects_score DESC -- 비교과성적이 우수한자
 	`).Rows()
 
 	if err != nil {
@@ -149,14 +149,14 @@ func QueryAllByAdditionalApplicant() (error, []types.Applicant) {
 		      o.entrance_intention_yn IS NULL AND 
 		      m.role = 'APPLICANT'
 		ORDER BY 
-		(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-		td.total_subjects_score DESC, 
-		(td.score_3_2 + td.score_3_1) DESC,
-		(td.score_2_2 + td.score_2_1) DESC, 
-		td.score_2_2 DESC, 
-		td.score_2_1 DESC, 
-		td.total_non_subjects_score DESC, 
-		m.birth ASC;
+		(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+		tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
+		td.general_subjects_score DESC, -- 일반교과성적이 우수한자
+		td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
+		td.score_2_2 DESC,
+		td.score_2_1 DESC,
+		td.score_1_2 DESC,
+		td.total_non_subjects_score DESC -- 비교과성적이 우수한자
 	`).Rows()
 
 	if err != nil {

--- a/repository/second_evaluation_job_repository.go
+++ b/repository/second_evaluation_job_repository.go
@@ -13,7 +13,7 @@ func UpdateSecondTestPassStatusForAbsentees(db *gorm.DB) error {
 			SET tbo.pass_yn = 'NO',
 				tbe.second_test_pass_yn = 'NO'
 			WHERE tbe.first_test_pass_yn = 'YES'
-				AND (tbe.aptitude_evaluation_score IS NULL OR tbe.interview_score IS NULL)
+				AND (tbe.competency_evaluation_score IS NULL OR tbe.interview_score IS NULL)
 		`
 
 	err := db.Exec(query).Error
@@ -51,7 +51,7 @@ func IsAllAbsenteeFall(db *gorm.DB) (bool, error) {
 			SELECT COUNT(*) 
 			FROM tb_entrance_test_result 
 			WHERE first_test_pass_yn = 'YES' 
-			  AND (aptitude_evaluation_score IS NULL OR interview_score IS NULL)
+			  AND (competency_evaluation_score IS NULL OR interview_score IS NULL)
 		`
 	var absenteeCount int
 	err := db.Raw(query).Scan(&absenteeCount).Error
@@ -89,14 +89,14 @@ func QueryExtraAdOneseoIds(db *gorm.DB) ([]int, error) {
 				o.applied_screening = 'EXTRA_ADMISSION' 
 				AND tr.second_test_pass_yn IS NULL
 			ORDER BY 
-				(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-				td.total_subjects_score DESC,
-				(td.score_3_2 + td.score_3_1) DESC,
-				(td.score_2_2 + td.score_2_1) DESC, 
-				td.score_2_2 DESC, 
-				td.score_2_1 DESC, 
-				td.total_non_subjects_score DESC, 
-				m.birth ASC;
+				(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+				tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
+				td.general_subjects_score DESC, -- 일반교과성적이 우수한자
+				td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
+				td.score_2_2 DESC,
+				td.score_2_1 DESC,
+				td.score_1_2 DESC,
+				td.total_non_subjects_score DESC -- 비교과성적이 우수한자
 		`
 	var ids []int
 	err := db.Raw(query).Scan(&ids).Error
@@ -152,14 +152,14 @@ func QueryExtraVeOneseoIds(db *gorm.DB) ([]int, error) {
 				o.applied_screening = 'EXTRA_VETERANS' 
 				AND tr.second_test_pass_yn IS NULL
 			ORDER BY 
-				(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-				td.total_subjects_score DESC,
-				(td.score_3_2 + td.score_3_1) DESC,
-				(td.score_2_2 + td.score_2_1) DESC, 
-				td.score_2_2 DESC, 
-				td.score_2_1 DESC, 
-				td.total_non_subjects_score DESC, 
-				m.birth ASC;
+				(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+				tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
+				td.general_subjects_score DESC, -- 일반교과성적이 우수한자
+				td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
+				td.score_2_2 DESC,
+				td.score_2_1 DESC,
+				td.score_1_2 DESC,
+				td.total_non_subjects_score DESC -- 비교과성적이 우수한자
 		`
 	var ids []int
 	err := db.Raw(query).Scan(&ids).Error
@@ -215,14 +215,14 @@ func QuerySpecialOneseoIds(db *gorm.DB) ([]int, error) {
 				o.applied_screening = 'SPECIAL'
 				AND tr.second_test_pass_yn IS NULL
 			ORDER BY 
-				(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-				td.total_subjects_score DESC,
-				(td.score_3_2 + td.score_3_1) DESC,
-				(td.score_2_2 + td.score_2_1) DESC, 
-				td.score_2_2 DESC, 
-				td.score_2_1 DESC, 
-				td.total_non_subjects_score DESC, 
-				m.birth ASC;
+				(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+				tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
+				td.general_subjects_score DESC, -- 일반교과성적이 우수한자
+				td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
+				td.score_2_2 DESC,
+				td.score_2_1 DESC,
+				td.score_1_2 DESC,
+				td.total_non_subjects_score DESC -- 비교과성적이 우수한자
 		`
 	var ids []int
 	err := db.Raw(query).Scan(&ids).Error
@@ -282,7 +282,7 @@ func UpdateSecondTestPassYnForGeneral(generalPassLimit int, db *gorm.DB) error {
 					o.applied_screening = 'GENERAL'
 					AND tr.second_test_pass_yn IS NULL
 				ORDER BY 
-					(((tr.document_evaluation_score / 3) * 0.5) + (tr.aptitude_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
+					(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
 					td.total_subjects_score DESC,
 					(td.score_3_2 + td.score_3_1) DESC,
 					(td.score_2_2 + td.score_2_1) DESC, 

--- a/repository/second_evaluation_job_repository.go
+++ b/repository/second_evaluation_job_repository.go
@@ -283,13 +283,13 @@ func UpdateSecondTestPassYnForGeneral(generalPassLimit int, db *gorm.DB) error {
 					AND tr.second_test_pass_yn IS NULL
 				ORDER BY 
 					(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-					td.total_subjects_score DESC,
-					(td.score_3_2 + td.score_3_1) DESC,
-					(td.score_2_2 + td.score_2_1) DESC, 
-					td.score_2_2 DESC, 
-					td.score_2_1 DESC, 
-					td.total_non_subjects_score DESC, 
-					m.birth ASC
+					tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
+					td.general_subjects_score DESC, -- 일반교과성적이 우수한자
+					td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
+					td.score_2_2 DESC,
+					td.score_2_1 DESC,
+					td.score_1_2 DESC,
+					td.total_non_subjects_score DESC -- 비교과성적이 우수한자
 				LIMIT ?
 			) AS subquery ON tr.entrance_test_result_id = subquery.entrance_test_result_id
 			JOIN tb_oneseo o ON subquery.oneseo_id = o.oneseo_id

--- a/repository/second_evaluation_job_repository.go
+++ b/repository/second_evaluation_job_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	e "themoment-team/go-hellogsm/error"
+	"themoment-team/go-hellogsm/repository/shared"
 
 	"gorm.io/gorm"
 )
@@ -90,16 +91,10 @@ func QueryExtraAdOneseoIds(db *gorm.DB) ([]int, error) {
 				AND tr.second_test_pass_yn IS NULL
 			ORDER BY 
 				(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-				tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
-				td.general_subjects_score DESC, -- 일반교과성적이 우수한자
-				td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
-				td.score_2_2 DESC,
-				td.score_2_1 DESC,
-				td.score_1_2 DESC,
-				td.total_non_subjects_score DESC -- 비교과성적이 우수한자
+				? -- 동점자 처리기준 (TieBreakerQuery)
 		`
 	var ids []int
-	err := db.Raw(query).Scan(&ids).Error
+	err := db.Raw(query, shared.FinalTieBreakerQuery).Scan(&ids).Error
 	if err != nil {
 		return nil, e.WrapRollbackNeededError(err)
 	}
@@ -153,16 +148,10 @@ func QueryExtraVeOneseoIds(db *gorm.DB) ([]int, error) {
 				AND tr.second_test_pass_yn IS NULL
 			ORDER BY 
 				(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-				tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
-				td.general_subjects_score DESC, -- 일반교과성적이 우수한자
-				td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
-				td.score_2_2 DESC,
-				td.score_2_1 DESC,
-				td.score_1_2 DESC,
-				td.total_non_subjects_score DESC -- 비교과성적이 우수한자
+				? -- 동점자 처리기준 (TieBreakerQuery)
 		`
 	var ids []int
-	err := db.Raw(query).Scan(&ids).Error
+	err := db.Raw(query, shared.FinalTieBreakerQuery).Scan(&ids).Error
 	if err != nil {
 		return nil, e.WrapRollbackNeededError(err)
 	}
@@ -216,16 +205,10 @@ func QuerySpecialOneseoIds(db *gorm.DB) ([]int, error) {
 				AND tr.second_test_pass_yn IS NULL
 			ORDER BY 
 				(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-				tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
-				td.general_subjects_score DESC, -- 일반교과성적이 우수한자
-				td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
-				td.score_2_2 DESC,
-				td.score_2_1 DESC,
-				td.score_1_2 DESC,
-				td.total_non_subjects_score DESC -- 비교과성적이 우수한자
+				? -- 동점자 처리기준 (TieBreakerQuery)
 		`
 	var ids []int
-	err := db.Raw(query).Scan(&ids).Error
+	err := db.Raw(query, shared.FinalTieBreakerQuery).Scan(&ids).Error
 	if err != nil {
 		return nil, e.WrapRollbackNeededError(err)
 	}
@@ -283,20 +266,14 @@ func UpdateSecondTestPassYnForGeneral(generalPassLimit int, db *gorm.DB) error {
 					AND tr.second_test_pass_yn IS NULL
 				ORDER BY 
 					(((tr.document_evaluation_score / 3) * 0.5) + (tr.competency_evaluation_score * 0.3) + (tr.interview_score * 0.2)) DESC, 
-					tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
-					td.general_subjects_score DESC, -- 일반교과성적이 우수한자
-					td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
-					td.score_2_2 DESC,
-					td.score_2_1 DESC,
-					td.score_1_2 DESC,
-					td.total_non_subjects_score DESC -- 비교과성적이 우수한자
+					? -- 동점자 처리기준 (TieBreakerQuery)
 				LIMIT ?
 			) AS subquery ON tr.entrance_test_result_id = subquery.entrance_test_result_id
 			JOIN tb_oneseo o ON subquery.oneseo_id = o.oneseo_id
 			SET tr.second_test_pass_yn = 'YES',
 				o.pass_yn = 'YES';
 		`
-	err := db.Exec(query, generalPassLimit).Error
+	err := db.Exec(query, shared.FinalTieBreakerQuery, generalPassLimit).Error
 	if err != nil {
 		return e.WrapRollbackNeededError(err)
 	}

--- a/repository/shared/tiebreaker_query.go
+++ b/repository/shared/tiebreaker_query.go
@@ -1,0 +1,19 @@
+package shared
+
+import "fmt"
+
+var (
+	CommonTieBreakerQuery = `
+	td.general_subjects_score DESC, -- 일반교과성적이 우수한자
+	td.score_3_1 DESC, -- 3-1,2-2,2-1,1-2 순으로 성적이 우수한자
+	td.score_2_2 DESC,
+	td.score_2_1 DESC,
+	td.score_1_2 DESC,
+	td.total_non_subjects_score DESC -- 비교과성적이 우수한자
+`
+	FinalTieBreakerQuery = fmt.Sprintf(`
+	%s
+	tr.competency_evaluation_score DESC, -- 역량검사 점수가 우수한자
+	tr.interview_score DESC, -- 면접 점수가 우수한자
+`, CommonTieBreakerQuery)
+)


### PR DESCRIPTION
올해 바뀐 동점자 처리 기준을 적용했습니다.

---
- 기존 동점자 처리기준
1) 교과성적(예·체능 교과포함)이 우수한 자
2) 교과성적(예·체능 교과 미포함)중 3학년, 2학년 순으로 우수한 자
3) 2학년 2학기, 2학년 1학기 교과성적(예·체능교과 미포함) 순으로 우수한 자
4) 1차 전형 점수 중 비교과 성적이 우수한 자
5) 생년월일이 빠른 자
- 새 동점자 처리기준
1) 2차 전형 점수 중 역량검사 점수가 우수한 자
2) 1차 전형 점수 중 교과 성적(예·체능 교과 미포함)이 우수한 자
3) 교과성적(예·체능 교과 미포함) 중 3학년 1학기, 2학년 2학기, 2학년 1학기, 1학년 2학기 순으로 우수한 자
4) 1차 전형 점수 중 비교과 성적이 우수한 자