### PR TITLE
1차 배치 시 수험번호 할당 작업 추가

### DIFF
--- a/jobs/my_job/examination_number_assignment_step.go
+++ b/jobs/my_job/examination_number_assignment_step.go
@@ -59,7 +59,7 @@ func validateBeforeExaminationNumberAssignment(db *gorm.DB) error {
 	if existingCount > 0 {
 		log.Printf("ERROR: 이미 [%d]개의 수험번호가 할당되어 있습니다.", existingCount)
 		log.Printf("수험번호 할당 작업이 이미 완료된 상태입니다. 중복 실행을 방지하기 위해 작업을 중단합니다.")
-		return e.WrapRollbackNeededError(e.WrapExpectedActualIsDiffError("수험번호가 이미 할당되어 있어 중복 실행을 방지합니다"))
+		return e.WrapExpectedActualIsDiffError("수험번호가 이미 할당되어 있어 중복 실행을 방지합니다")
 	}
 	return nil
 }
@@ -70,7 +70,7 @@ func validateAfterExaminationNumberAssignment(db *gorm.DB) error {
 	unassignedCount := repository.CountFirstPassWithoutExaminationNumber(db)
 	if unassignedCount > 0 {
 		log.Printf("ERROR: [%d]명의 1차 합격자에게 수험번호가 할당되지 않았습니다.", unassignedCount)
-		return e.WrapRollbackNeededError(e.WrapExpectedActualIsDiffError("일부 1차 합격자에게 수험번호가 할당되지 않았습니다"))
+		return e.WrapExpectedActualIsDiffError("일부 1차 합격자에게 수험번호가 할당되지 않았습니다")
 	}
 
 	// 수험번호 형식 검증

--- a/jobs/my_job/examination_number_assignment_step.go
+++ b/jobs/my_job/examination_number_assignment_step.go
@@ -1,0 +1,137 @@
+package my_job
+
+import (
+	"gorm.io/gorm"
+	"log"
+	e "themoment-team/go-hellogsm/error"
+	"themoment-team/go-hellogsm/jobs"
+	"themoment-team/go-hellogsm/repository"
+)
+
+// AssignExaminationNumberStep 수험번호를 할당하는 Step이다.
+type AssignExaminationNumberStep struct {
+}
+
+func (s *AssignExaminationNumberStep) Processor(batchContext *jobs.BatchContext, db *gorm.DB) error {
+	log.Println("수험번호 할당을 시작합니다.")
+
+	// 수험번호 할당 전 검증
+	err := validateBeforeExaminationNumberAssignment(db)
+	if err != nil {
+		return err
+	}
+
+	// 할당 통계 로그
+	totalFirstPass, _, rooms := getExaminationNumberStatistics(db)
+	logExaminationNumberAssignmentStart(totalFirstPass, rooms)
+
+	// 수험번호 할당 실행
+	err = repository.AssignExaminationNumbers(db)
+	if err != nil {
+		log.Printf("수험번호 할당 중 오류 발생: %v", err)
+		return err
+	}
+
+	// 수험번호 할당 후 검증
+	err = validateAfterExaminationNumberAssignment(db)
+	if err != nil {
+		return err
+	}
+
+	// 최종 결과 로그
+	_, assignedCount, finalRooms := getExaminationNumberStatistics(db)
+	logExaminationNumberAssignmentComplete(assignedCount, finalRooms)
+
+	// 할당 결과 샘플 로그
+	logExaminationNumberSamples(db)
+
+	log.Println("수험번호 할당이 완료되었습니다.")
+	return nil
+}
+
+// 수험번호 할당 전 검증
+func validateBeforeExaminationNumberAssignment(db *gorm.DB) error {
+	log.Println("수험번호 할당 전 검증을 시작합니다.")
+
+	// 1차 합격자 존재 여부 확인
+	firstPassCount := repository.CountFirstPassApplicants(db)
+	if firstPassCount == 0 {
+		return e.WrapExpectedActualIsDiffError("1차 합격자가 존재하지 않아 수험번호 할당이 불가능합니다")
+	}
+	log.Printf("1차 합격자 [%d]명을 확인했습니다.", firstPassCount)
+
+	// 기존 수험번호 할당 여부 확인 - 중복 실행 방지
+	existingCount := repository.CountExistingExaminationNumbers(db)
+	if existingCount > 0 {
+		log.Printf("ERROR: 이미 [%d]개의 수험번호가 할당되어 있습니다.", existingCount)
+		log.Printf("수험번호 할당 작업이 이미 완료된 상태입니다. 중복 실행을 방지하기 위해 작업을 중단합니다.")
+		return e.WrapRollbackNeededError(e.WrapExpectedActualIsDiffError("수험번호가 이미 할당되어 있어 중복 실행을 방지합니다"))
+	}
+	log.Println("기존 수험번호 할당이 없음을 확인했습니다.")
+
+	log.Println("수험번호 할당 전 검증이 완료되었습니다.")
+	return nil
+}
+
+// 수험번호 할당 후 검증
+func validateAfterExaminationNumberAssignment(db *gorm.DB) error {
+	log.Println("수험번호 할당 후 검증을 시작합니다.")
+
+	// 모든 1차 합격자에게 수험번호가 할당되었는지 확인
+	unassignedCount := repository.CountFirstPassWithoutExaminationNumber(db)
+	if unassignedCount > 0 {
+		log.Printf("ERROR: [%d]명의 1차 합격자에게 수험번호가 할당되지 않았습니다.", unassignedCount)
+		return e.WrapRollbackNeededError(e.WrapExpectedActualIsDiffError("일부 1차 합격자에게 수험번호가 할당되지 않았습니다"))
+	}
+
+	// 수험번호 형식 검증
+	err := repository.ValidateExaminationNumberFormat(db)
+	if err != nil {
+		log.Printf("ERROR: 수험번호 형식 검증 실패: %v", err)
+		return e.WrapRollbackNeededError(err)
+	}
+
+	// 수험번호 중복 검증
+	err = repository.ValidateExaminationNumberUniqueness(db)
+	if err != nil {
+		log.Printf("ERROR: 수험번호 중복 검증 실패: %v", err)
+		return e.WrapRollbackNeededError(err)
+	}
+
+	log.Println("수험번호 할당 후 검증이 완료되었습니다.")
+	return nil
+}
+
+// 수험번호 할당 통계를 반환한다
+func getExaminationNumberStatistics(db *gorm.DB) (totalFirstPass int, assignedExamNumber int, rooms int) {
+	totalFirstPass = repository.CountFirstPassApplicants(db)
+	assignedExamNumber = repository.CountExistingExaminationNumbers(db)
+
+	// 필요한 고사실 수 (16명당 1개 고사실)
+	if totalFirstPass > 0 {
+		rooms = (totalFirstPass + 15) / 16 // 올림 계산
+	}
+
+	return totalFirstPass, assignedExamNumber, rooms
+}
+
+// 수험번호 할당 시작 로그
+func logExaminationNumberAssignmentStart(totalFirstPass int, rooms int) {
+	log.Printf("1차 합격자 [%d]명에 대해 수험번호를 할당합니다. (필요 고사실: [%d]개)", totalFirstPass, rooms)
+}
+
+// 수험번호 할당 완료 로그
+func logExaminationNumberAssignmentComplete(assignedCount int, rooms int) {
+	log.Printf("수험번호 할당이 완료되었습니다. 할당된 수험번호: [%d]개, 사용된 고사실: [%d]개", assignedCount, rooms)
+}
+
+// 할당된 수험번호 샘플 로그
+func logExaminationNumberSamples(db *gorm.DB) {
+	samples := repository.GetExaminationNumberSamples(db, 10)
+
+	log.Println("=== 할당된 수험번호 샘플 (첫 10명) ===")
+	for _, sample := range samples {
+		log.Printf("이름: [%s], 전형: [%s], 수험번호: [%s]",
+			sample.Name, sample.AppliedScreening, sample.ExaminationNumber)
+	}
+}

--- a/jobs/my_job/first_evaluation_job.go
+++ b/jobs/my_job/first_evaluation_job.go
@@ -17,7 +17,10 @@ type DecideAppliedScreeningStep struct {
 
 // job 에 필요한 step 들을 반환한다.
 func getSteps() []jobs.Step {
-	return []jobs.Step{&DecideAppliedScreeningStep{}}
+	return []jobs.Step{
+		&DecideAppliedScreeningStep{},
+		&AssignExaminationNumberStep{},
+	}
 }
 
 // BuildFirstEvaluationJob 1차 평가 배치 Job을 생성한다.

--- a/repository/examination_number_repository.go
+++ b/repository/examination_number_repository.go
@@ -112,10 +112,6 @@ func GetExaminationNumberSamples(db *gorm.DB, limit int) []ExaminationNumberSamp
 	return samples
 }
 
-func HasFirstPassApplicantsWithDB(db *gorm.DB) bool {
-	return CountFirstPassApplicants(db) > 0
-}
-
 func HasFirstPassApplicants() bool {
 	var count int
 	configs.MyDB.Raw(`

--- a/repository/examination_number_repository.go
+++ b/repository/examination_number_repository.go
@@ -1,0 +1,159 @@
+package repository
+
+import (
+	"gorm.io/gorm"
+	"themoment-team/go-hellogsm/configs"
+	e "themoment-team/go-hellogsm/error"
+)
+
+type ExaminationNumberSample struct {
+	Name              string
+	AppliedScreening  string
+	ExaminationNumber string
+}
+
+func AssignExaminationNumbers(db *gorm.DB) error {
+	query := `
+WITH FirstPassApplicants AS (
+    SELECT 
+        o.oneseo_id,
+        m.name,
+        o.applied_screening,
+        ROW_NUMBER() OVER (ORDER BY m.name ASC, o.oneseo_id ASC) AS row_num
+    FROM tb_oneseo o
+    JOIN tb_member m ON o.member_id = m.member_id
+    WHERE o.applied_screening IS NOT NULL 
+      AND o.real_oneseo_arrived_yn = 'YES'
+)
+UPDATE tb_oneseo AS o
+JOIN FirstPassApplicants AS fpa ON o.oneseo_id = fpa.oneseo_id
+SET o.examination_number = CONCAT(
+    LPAD(FLOOR((fpa.row_num - 1) / 16) + 1, 2, '0'),
+    LPAD(((fpa.row_num - 1) % 16) + 1, 2, '0')
+);`
+
+	err := db.Exec(query).Error
+	if err != nil {
+		return e.WrapRollbackNeededError(err)
+	}
+
+	return nil
+}
+
+func CountFirstPassApplicants(db *gorm.DB) int {
+	var count int
+	db.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_oneseo 
+		WHERE applied_screening IS NOT NULL 
+		  AND real_oneseo_arrived_yn = 'YES'
+	`).Scan(&count)
+	return count
+}
+
+func CountExistingExaminationNumbers(db *gorm.DB) int {
+	var count int
+	db.Raw("SELECT COUNT(*) FROM tb_oneseo WHERE examination_number IS NOT NULL").Scan(&count)
+	return count
+}
+
+func CountFirstPassWithoutExaminationNumber(db *gorm.DB) int {
+	var count int
+	db.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_oneseo 
+		WHERE applied_screening IS NOT NULL 
+		  AND real_oneseo_arrived_yn = 'YES' 
+		  AND examination_number IS NULL
+	`).Scan(&count)
+	return count
+}
+
+func ValidateExaminationNumberFormat(db *gorm.DB) error {
+	var invalidCount int
+	db.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_oneseo 
+		WHERE examination_number IS NOT NULL 
+		  AND examination_number NOT REGEXP '^[0-9]{4}$'
+	`).Scan(&invalidCount)
+
+	if invalidCount > 0 {
+		return e.WrapExpectedActualIsDiffError("수험번호 형식이 올바르지 않은 데이터 존재")
+	}
+	return nil
+}
+
+func ValidateExaminationNumberUniqueness(db *gorm.DB) error {
+	var duplicateCount int
+	db.Raw(`
+		SELECT COUNT(*) - COUNT(DISTINCT examination_number)
+		FROM tb_oneseo 
+		WHERE examination_number IS NOT NULL
+	`).Scan(&duplicateCount)
+
+	if duplicateCount > 0 {
+		return e.WrapExpectedActualIsDiffError("중복된 수험번호 존재")
+	}
+	return nil
+}
+
+func GetExaminationNumberSamples(db *gorm.DB, limit int) []ExaminationNumberSample {
+	var samples []ExaminationNumberSample
+	db.Raw(`
+		SELECT m.name, o.applied_screening, o.examination_number
+		FROM tb_oneseo o
+		JOIN tb_member m ON o.member_id = m.member_id
+		WHERE o.examination_number IS NOT NULL
+		ORDER BY o.examination_number ASC
+		LIMIT ?
+	`, limit).Scan(&samples)
+
+	return samples
+}
+
+func HasFirstPassApplicantsWithDB(db *gorm.DB) bool {
+	return CountFirstPassApplicants(db) > 0
+}
+
+func HasFirstPassApplicants() bool {
+	var count int
+	configs.MyDB.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_oneseo 
+		WHERE applied_screening IS NOT NULL 
+		  AND real_oneseo_arrived_yn = 'YES'
+	`).Scan(&count)
+	return count > 0
+}
+
+func HasOneseoWithExaminationNumber() bool {
+	var count int
+	configs.MyDB.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_oneseo 
+		WHERE examination_number IS NOT NULL
+	`).Scan(&count)
+	return count > 0
+}
+
+func GetExaminationNumberStats() (totalFirstPass int, assignedExamNumber int, rooms int) {
+	configs.MyDB.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_oneseo 
+		WHERE applied_screening IS NOT NULL 
+		  AND real_oneseo_arrived_yn = 'YES'
+	`).Scan(&totalFirstPass)
+
+	configs.MyDB.Raw(`
+		SELECT COUNT(*) 
+		FROM tb_oneseo 
+		WHERE examination_number IS NOT NULL
+	`).Scan(&assignedExamNumber)
+
+	if totalFirstPass > 0 {
+		rooms = (totalFirstPass + 15) / 16
+	}
+
+	return totalFirstPass, assignedExamNumber, rooms
+}


### PR DESCRIPTION
1차 배치 작업 시 추가적으로 ``examination_number``(수험번호) 필드을 할당하는 작업을 추가하였습니다.

---

수험번호 필드의 특성상 4자리 정수로 구성되고 처음 두자리는 고사장 번호(ex: **01**xx)이며 뒷 두자리는 해당 고사장에서 수험자의 번호입니다(ex: xx**01**)
예를 들어 2번 고사장의 14번째 수험자라면 ``0214`` 와 같이 구성됩니다
작년 2025학년도 신입생 입학을 위한 운영기간에는 직접 쿼리문을 구성하여 DB로 쿼리하는 방식으로 해결하였는데 올해 2026학년도 신입생 입학 지원 기간에는 기존 1차 배치에 후속작업으로 추가하여 자동으로 수험번호를 할당하도록 하였습니다.

---

우선적으로 수험자의 '이름' 기준으로 정렬 후 수험번호를 할당하며 **한 고사장엔 16명 정원이라는 규칙**을 적용해 수험자에게 ``0116``이 할당된다면 그 다음 수험자에게는 ``0201``이라는 수험번호를 할당하도록 구현하였습니다.

---
구현 후 배치 작업 로그입니다(Discord Relay 서버 연결 실패는 환경변수 값을 주입하지 않아 실패한 것입니다! 참고해주세요)
[go-hellogsm-수험번호_할당_로직.txt](https://github.com/user-attachments/files/21290188/go-hellogsm-._._.txt)
