### PR TITLE
고사상 실황에 맞도록 수험번호 할당 로직 변경

### DIFF
--- a/jobs/my_job/examination_number_assignment_step.go
+++ b/jobs/my_job/examination_number_assignment_step.go
@@ -1,11 +1,12 @@
 package my_job
 
 import (
-	"gorm.io/gorm"
 	"log"
 	e "themoment-team/go-hellogsm/error"
 	"themoment-team/go-hellogsm/jobs"
 	"themoment-team/go-hellogsm/repository"
+
+	"gorm.io/gorm"
 )
 
 type AssignExaminationNumberStep struct {
@@ -68,9 +69,17 @@ func validateBeforeExaminationNumberAssignment(db *gorm.DB) error {
 func validateAfterExaminationNumberAssignment(db *gorm.DB) error {
 	// 모든 1차 합격자에게 수험번호가 할당되었는지 확인
 	unassignedCount := repository.CountFirstPassWithoutExaminationNumber(db)
+	overflow := repository.GetOverflowApplicants(db)
 	if unassignedCount > 0 {
-		log.Printf("ERROR: [%d]명의 1차 합격자에게 수험번호가 할당되지 않았습니다.", unassignedCount)
-		return e.WrapExpectedActualIsDiffError("일부 1차 합격자에게 수험번호가 할당되지 않았습니다")
+		if unassignedCount == len(overflow) {
+			log.Printf("좌석 수 초과로 수험번호 미부여된 인원: [%d]명", len(overflow))
+			for i, o := range overflow {
+				log.Printf("초과자 #%d: 이름=[%s], 적용전형=[%s], 제출코드=[%s]", i+1, o.Name, o.AppliedScreening, o.OneseoSubmitCode)
+			}
+		} else {
+			log.Printf("ERROR: 수험번호 미할당자 수 [%d]명, 초과자 수 [%d]명 불일치", unassignedCount, len(overflow))
+			return e.WrapExpectedActualIsDiffError("일부 1차 합격자에게 수험번호가 할당되지 않았습니다")
+		}
 	}
 
 	// 수험번호 형식 검증
@@ -97,7 +106,17 @@ func getExaminationNumberStatistics(db *gorm.DB) (totalFirstPass int, assignedEx
 	assignedExamNumber = repository.CountExistingExaminationNumbers(db)
 
 	if totalFirstPass > 0 {
-		rooms = (totalFirstPass + 15) / 16
+		// 18,18,18,18,12,11 기준으로 필요한 고사실 수 산정, 추후 고사실 상황 변동 시 수정 필요
+		caps := []int{18, 18, 18, 18, 12, 11}
+		remain := totalFirstPass
+		rooms = 0
+		for _, c := range caps {
+			if remain <= 0 {
+				break
+			}
+			rooms++
+			remain -= c
+		}
 	}
 
 	return totalFirstPass, assignedExamNumber, rooms

--- a/jobs/my_job/examination_number_assignment_step.go
+++ b/jobs/my_job/examination_number_assignment_step.go
@@ -5,6 +5,7 @@ import (
 	e "themoment-team/go-hellogsm/error"
 	"themoment-team/go-hellogsm/jobs"
 	"themoment-team/go-hellogsm/repository"
+	"themoment-team/go-hellogsm/types"
 
 	"gorm.io/gorm"
 )
@@ -106,11 +107,9 @@ func getExaminationNumberStatistics(db *gorm.DB) (totalFirstPass int, assignedEx
 	assignedExamNumber = repository.CountExistingExaminationNumbers(db)
 
 	if totalFirstPass > 0 {
-		// 18,18,18,18,12,11 기준으로 필요한 고사실 수 산정, 추후 고사실 상황 변동 시 수정 필요
-		caps := []int{18, 18, 18, 18, 12, 11}
 		remain := totalFirstPass
 		rooms = 0
-		for _, c := range caps {
+		for _, c := range types.ExaminationRoomCapacities {
 			if remain <= 0 {
 				break
 			}

--- a/repository/examination_number_repository.go
+++ b/repository/examination_number_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"themoment-team/go-hellogsm/configs"
 	e "themoment-team/go-hellogsm/error"
+	"themoment-team/go-hellogsm/types"
 
 	"gorm.io/gorm"
 )
@@ -209,11 +210,9 @@ func GetExaminationNumberStats() (totalFirstPass int, assignedExamNumber int, ro
 	`).Scan(&assignedExamNumber)
 
 	if totalFirstPass > 0 {
-		// 18,18,18,18,12,11 기준으로 필요한 방 수 추정
-		caps := []int{18, 18, 18, 18, 12, 11}
 		remain := totalFirstPass
 		rooms = 0
-		for _, c := range caps {
+		for _, c := range types.ExaminationRoomCapacities {
 			if remain <= 0 {
 				break
 			}

--- a/types/constant.go
+++ b/types/constant.go
@@ -49,3 +49,6 @@ const (
 	// 그냥 전체. 발생하지 않을 수
 	JustAll int = 99999
 )
+
+// 고사실 정원 (고사장 상황 변동 시 수정 필요)
+var ExaminationRoomCapacities = []int{18, 18, 18, 18, 12, 11}


### PR DESCRIPTION
각 고사장에서 
- 18, 18, 18, 18, 12, 11

다음 순에 맞게 고사장을 할당하도록 수정하였으며 95명이 넘어간다면 로그를 남기고 수동으로 할당하도록 구현하였습니다.